### PR TITLE
Fix data type for header size to be 64 bits even on 32 bit systems.

### DIFF
--- a/src/websocket.c
+++ b/src/websocket.c
@@ -778,7 +778,7 @@ vws_buffer* vws_serialize(vws_frame* f)
     //> Section 1: Size calculation
 
     // Calculate the frame size
-    size_t payload_length = f->size;
+    uint64_t payload_length = f->size;
 
     // Set the mask bit and payload length. Maximum frame size with extended
     // payload length and masking key
@@ -1289,7 +1289,7 @@ void dump_websocket_header(const ws_header* header)
     printf("  fin:      %u\n", header->fin);
     printf("  opcode:   %u\n", header->opcode);
     printf("  mask:     %u (0x%08x)\n", header->mask, header->masking_key);
-    printf("  payload:  %lu bytes\n", header->payload_len);
+    printf("  payload:  %" PRIu64 " bytes\n", header->payload_len);
     printf("\n");
 }
 


### PR DESCRIPTION
The header payload length is defined as a `size_t` variable. The code as is fails to compile on:
* 64 bit MacOs - "%lu" is the wrong format for `size_t`.
* 32 bit Arm Linux - `size_t` is only 32 bits, so shifts of 32 bits or more will not compile.

This changes the data type to the explicitly 64 bit type `uint64_t` with the appropriate printf format specifier.