### PR TITLE
Use compatible sprintf format for size_t

### DIFF
--- a/src/test/test_common.c
+++ b/src/test/test_common.c
@@ -133,8 +133,8 @@ CTEST2(test, map_bench)
     // Find and print values
     for (size_t i = 0; i < size; i++)
     {
-        sprintf(&kbuf[0],"key%i", i);
-        sprintf(&vbuf[0],"value%i", i);
+        sprintf(&kbuf[0],"key%zu", i);
+        sprintf(&vbuf[0],"value%zu", i);
 
         keys[i]   = strdup(&kbuf[i]);
         values[i] = strdup(&vbuf[i]);


### PR DESCRIPTION
In test_common.c, sprintf uses the "%i" formatter for a size_t. On certain compilers (i.e. gcc 13.2.0 on my build machine), this causes a warning. In CMakeLists.txt, warnings are set to be errrors (-Werror), so the code will not build.
The fix is to use "%zu" for ISO C99 compatibility.