### PR TITLE
docs: document hardening-era changes + fix doc HTML build

### DIFF
--- a/doc/scripts/.emacs
+++ b/doc/scripts/.emacs
@@ -1,3 +1,9 @@
+;; Put ELPA packages (htmlize, used by code2html.el) on load-path. In
+;; `emacs -batch` the package system is not auto-initialized, so without this
+;; `(load "htmlize.el")` fails with "Cannot open load file".
+(require 'package)
+(package-initialize)
+
 (if (fboundp 'scroll-bar-mode) (scroll-bar-mode -1))
 (if (fboundp 'tool-bar-mode) (tool-bar-mode -1))
 (if (fboundp 'menu-bar-mode) (menu-bar-mode -1))

--- a/doc/xml/ws.api.xml
+++ b/doc/xml/ws.api.xml
@@ -76,6 +76,17 @@ the frame type (<literal>TEXT</literal> or
 the message will have the <literal>FIN</literal> bit set, signifying the end of
 the message. This covers the structural part of the API.</para>
 
+<note><title>Maximum Frame Size</title>
+
+  <para>The library caps the payload length of a single frame at
+  <constant>VWS_MAX_FRAME_SIZE</constant> (64 MiB by default). A frame whose
+  payload exceeds this limit is rejected as a frame error
+  (<constant>FRAME_ERROR</constant>) before any memory is allocated for it. The
+  cap is a compile-time tunable defined in <filename>src/websocket.c</filename>;
+  see <xref linkend="ws.overview.concepts"/> for further detail.</para>
+
+</note>
+
 </section> <!-- ws.api.client.structures -->
 
 <section id="ws.api.client.functions"><title>Functions</title>

--- a/doc/xml/ws.intro.xml
+++ b/doc/xml/ws.intro.xml
@@ -76,6 +76,28 @@ original intent was to provide client-side connections only. Thus if you want
 use the server-side API, you simple add a configuration switch at build time to
 include the code (covered in <xref linkend="ws.build"/>).</para>
 
+<note><title>Experimental Async Reactor</title>
+
+  <para>The library also contains an experimental, non-blocking,
+  single-connection asynchronous reactor (<filename>src/async.h</filename>) that
+  operates without <filename>libuv</filename>. It is presently low-level
+  foundation: its ergonomic public interface stabilizes with the forthcoming C++
+  <classname>Channel</classname> wrapper and will be documented once that wrapper
+  lands. It is not yet part of the supported public API.</para>
+
+</note>
+
+<note><title>Recent Changes</title>
+
+  <para>The current release is a hardening release. It adds wire-reachable
+  denial-of-service protections (a frame-size cap and additional parser guards),
+  fixes a number of send-path and concurrency defects, widens the HTTP
+  status-code accessor to a full <type>int</type>, and introduces the
+  experimental asynchronous reactor described above together with an expanded
+  test suite.</para>
+
+</note>
+
 </section> <!-- ws.intro.about -->
 
 <section id="ws.intro.ws"><title>WebSocket Overview</title>
@@ -120,6 +142,15 @@ size limit may be smaller due to network or system constraints). There are
 several types of frames, including text frames, binary frames, continuation
 frames, and control frames.</para>
 
+<para>While the protocol permits very large frames, this library enforces a
+maximum frame size to guard against malformed or hostile peers. A single frame
+whose payload length exceeds <constant>VWS_MAX_FRAME_SIZE</constant> &mdash; 64
+MiB by default &mdash; is rejected as a frame error
+(<constant>FRAME_ERROR</constant>) before any allocation is attempted. This
+limit is a compile-time tunable, defined as a <literal>#define</literal> in
+<filename>src/websocket.c</filename>; it may be raised and the library
+recompiled should your application require larger frames.</para>
+
 <para>Text frames contain Unicode text data, while binary frames carry binary
 data. Continuation frames allow for larger messages to be broken down into
 smaller chunks. Control frames handle protocol-level interactions and include
@@ -145,6 +176,34 @@ system. Build as follows:
 <prompt>$</prompt> make
 <prompt>$</prompt> sudo make install
 </screen>
+
+</para>
+
+<para>Several CMake options control what is built and how. Each is passed on the
+<command>cmake</command> command line in the usual way, for example
+<literal>cmake -DBUILD_SERVER=OFF .</literal>. The available options are:
+
+<itemizedlist>
+
+<listitem><para><varname>BUILD_SERVER</varname> (default <literal>ON</literal>)
+builds the optional server-side component. The server depends on
+<filename>libuv</filename>, which is located at configure time via
+<literal>find_package(LibUV REQUIRED)</literal>. When
+<varname>BUILD_SERVER</varname> is enabled, <filename>libuv</filename> and its
+development headers must be installed. The client-side library has no such
+dependency.</para></listitem>
+
+<listitem><para><varname>ASAN</varname> (default <literal>OFF</literal>) builds
+the library and tests with the AddressSanitizer instrumentation for detecting
+memory errors.</para></listitem>
+
+<listitem><para><varname>VWS_TSAN</varname> (default <literal>OFF</literal>)
+builds the library and tests with the ThreadSanitizer instrumentation for
+detecting data races. Like <varname>ASAN</varname>, it is intended for
+development and testing and should be left off for production builds.</para>
+</listitem>
+
+</itemizedlist>
 
 </para>
 


### PR DESCRIPTION
Updates the DocBook docs for the user-visible changes since the hardening work, and repairs the doc HTML build. Three source files.

## Doc content
- **`ws.intro.xml`**: the `VWS_MAX_FRAME_SIZE` limit (64 MiB single-frame payload cap; oversize → `FRAME_ERROR`); the `VWS_TSAN` build option (ThreadSanitizer race build, default OFF); a brief **"Async (experimental)"** note that the non-blocking reactor capability exists, with its API to stabilize under the forthcoming C++ `Channel` wrapper; and a high-level change summary.
- **`ws.api.xml`**: frame-size limit cross-reference.

## Build fix
- **`doc/scripts/.emacs`**: add `(require 'package)` + `(package-initialize)` so `emacs -batch` finds the ELPA `htmlize` package. Without it the doc `make` failed with "Cannot open load file" and produced no HTML.

All doc content grounded to header source (no invented APIs); the async note cites only `async.h` + the Channel wrapper (no low-level reactor API leaked, since that surface stabilizes with Channel). `xmllint --xinclude --loaddtd` clean. Generated HTML/DTD output excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)