### PR TITLE
Windows (MinGW) cross-compile: portable fixes for the client core

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ if (CMAKE_C_COMPILER_ID MATCHES "Clang")
 endif()
 
 include_directories(
+  ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/llhttp
   ${CMAKE_CURRENT_SOURCE_DIR}/mpack

--- a/src/async.c
+++ b/src/async.c
@@ -7,6 +7,7 @@
 #endif
 
 #if defined(__windows__)
+#define WIN32_LEAN_AND_MEAN
 #define _WIN32_WINNT 0x0601
 #include <winsock2.h>
 #include <ws2tcpip.h>

--- a/src/socket.c
+++ b/src/socket.c
@@ -10,6 +10,7 @@
 #endif
 
 #if defined(__windows__)
+#define WIN32_LEAN_AND_MEAN
 #define _WIN32_WINNT 0x0601  // Windows 7 or later
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -151,7 +152,11 @@ void vws_socket_dtor(vws_socket* s)
 
     if (s->sockfd >= 0)
     {
+        #if defined(__windows__)
+        closesocket(s->sockfd);
+        #else
         close(s->sockfd);
+        #endif
     }
 
     // Free connection
@@ -224,7 +229,7 @@ bool socket_set_timeout(int fd, int sec)
 
     #elif defined(__windows__)
 
-    if (fd == INVALID_SOCKET)
+    if (fd < 0)
     {
         vws.error(VE_RT, "Invalid socket descriptor");
         return false;
@@ -496,7 +501,11 @@ ssize_t vws_socket_read(vws_socket* c)
         return -1;
     }
 
+    #if defined(__windows__)
+    WSAPOLLFD fds;
+    #else
     struct pollfd fds;
+    #endif
     int poll_events = POLLIN;
 
 openssl_reread:
@@ -517,7 +526,6 @@ openssl_reread:
 
     #elif defined(__windows__)
 
-    WSAPOLLFD fds;
     fds.fd     = c->sockfd;
     fds.events = POLLIN;
 
@@ -1056,7 +1064,11 @@ void vws_socket_close(vws_socket* c)
         #endif
         {
             char buf[256];
+            #if defined(__windows__)
+            strerror_s(buf, sizeof(buf), errno);
+            #else
             strerror_r(errno, buf, sizeof(buf));
+            #endif
             vws.error(VE_WARN, "Socket close failed: %s", buf);
         }
         #if defined(__windows__)
@@ -1132,7 +1144,7 @@ int connect_to_host(const char* host, const char* port)
 
     WSADATA wsaData;
     struct addrinfo *result = NULL, *ptr = NULL, hints;
-    sockfd = INVALID_SOCKET;
+    sockfd = -1;
 
     // Initialize Winsock
     if (WSAStartup(MAKEWORD(2,2), &wsaData) != 0)
@@ -1159,7 +1171,7 @@ int connect_to_host(const char* host, const char* port)
         // Create a SOCKET for connecting to server
         sockfd = socket(ptr->ai_family, ptr->ai_socktype, ptr->ai_protocol);
 
-        if (sockfd == INVALID_SOCKET)
+        if (sockfd < 0)
         {
             char buf[256];
             int e = WSAGetLastError();
@@ -1174,7 +1186,7 @@ int connect_to_host(const char* host, const char* port)
         if (connect(sockfd, ptr->ai_addr, (int)ptr->ai_addrlen) == SOCKET_ERROR)
         {
             closesocket(sockfd);
-            sockfd = INVALID_SOCKET;
+            sockfd = -1;
             continue;
         }
 
@@ -1183,7 +1195,7 @@ int connect_to_host(const char* host, const char* port)
 
     freeaddrinfo(result);
 
-    if (sockfd == INVALID_SOCKET)
+    if (sockfd < 0)
     {
         vws.error(VE_SYS, "Unable to connect to host");
         WSACleanup();

--- a/src/vws.c
+++ b/src/vws.c
@@ -8,6 +8,7 @@
 #endif
 
 #if defined(__windows__)
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 
@@ -77,10 +78,12 @@ const log_level_info log_level_infos[VL_LEVEL_COUNT] =
     { ANSI_COLOR_RED,     "CRIT" }
 };
 
+#if !defined(__windows__)
 static void unlock_mutex(void* arg)
 {
     pthread_mutex_unlock((pthread_mutex_t*)arg);
 }
+#endif
 
 void vws_trace_lock()
 {

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -4,6 +4,7 @@
 #endif
 
 #if defined(__windows__)
+#define WIN32_LEAN_AND_MEAN
 #define _WIN32_WINNT 0x0601  // Windows 7 or later
 #include <winsock2.h>
 #include <ws2tcpip.h>


### PR DESCRIPTION
Makes the vws **client core** cross-compile for Win64 with MinGW (`x86_64-w64-mingw32`), with **no regression on Linux**. Validated against an actual cross-build, not just review.

## Result
- **Win64 `BUILD_SERVER=0`**: builds clean → `libvws.dll` (PE x86-64), imports resolved (ws2_32 / libssl / libcrypto / kernel32 / msvcrt / libgcc). OpenSSL 1.1.1w cross-built.
- **Linux**: same sources build green (0 err / 0 warn), `test_async` identical to base (the pre-existing environmental `ssl_*` cases unchanged). No POSIX regression.

## Fixes (5 files, all Windows-branch-only or portable)
- **`WIN32_LEAN_AND_MEAN`** before `<winsock2.h>`/`<windows.h>` — the real blocker: `windows.h` dragged in the winscard/RPC chain, colliding with vws's own `rpc.h` (~1200 errors/TU).
- **`src/CMakeLists.txt`**: add `${CMAKE_CURRENT_BINARY_DIR}` to the include path so the generated `common.h` is found in out-of-tree builds (helps all platforms).
- **`socket.c`**: `closesocket()` on Windows, `strerror_s`, pollfd declaration-before-label, int sentinel.
- **`vws.c`**: guard a POSIX-only mutex-unlock path out of the Windows build.
- Uses the project's canonical `__windows__` platform macro throughout.

## Deferred (tracked follow-up)
`int sockfd` vs Win64 `SOCKET` (64-bit handle) truncation — needs a struct-wide socket-handle-type change across all `sockfd` users, out of scope for this client-core pass. The build works because the truncation isn't exercised in the cases here; full Win64 socket correctness is the follow-up.

Server component (`BUILD_SERVER=1`, needs libuv) is a later step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)