### PR TITLE
Install the generated common.h (fixes uncompilable <vws/vws.h> from an install)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,6 +136,12 @@ install( TARGETS shared_lib
   GROUP_READ GROUP_EXECUTE
   WORLD_READ WORLD_EXECUTE )
 
+# common.h is generated (configure_file) into the build dir, so it is NOT in the
+# ${HEADERS} source list above and would be missing from the install -- yet the
+# public vws.h #includes it. Install the generated copy so <vws/vws.h> compiles
+# against a clean install.
+install( FILES "${CMAKE_CURRENT_BINARY_DIR}/common.h" DESTINATION include/vws )
+
 install( DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/llhttp"
          DESTINATION "include/vws"
          FILES_MATCHING


### PR DESCRIPTION
`common.h` is `configure_file`-generated into the build dir (`CMakeLists.txt:27-28`) and is **not** in the `${HEADERS}` source list, so `make install` never ships it — yet the public `vws.h:9` does `#include "common.h"`. Result: a clean install's `include/vws/vws.h` **fails to compile for any external consumer** (`common.h: No such file or directory`).

Fix: `install(FILES ${CMAKE_CURRENT_BINARY_DIR}/common.h DESTINATION include/vws)`.

Surfaced by building the new **websockets-examples** against a clean `libvws` install — the anti-drift mechanism working as intended (real consumer caught a real packaging bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)