### PR TITLE
docs: overhaul README for onboarding + hardening-era accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,118 +2,169 @@
 
 ## Description
 
-This is a robust and performance-oriented WebSockets library written in C. It
-provides a simple yet flexible API for building WebSocket clients and
-servers. It supports all standard WebSocket features including text and binary
-messages, ping/pong frames, control frames and includes built-in OpenSSL
-support.
+VRTQL WebSockets is a robust, performance-oriented WebSocket library written in
+C. It provides a simple yet flexible API for building both WebSocket **clients**
+and **servers**, and it supports all standard WebSocket features: text and binary
+messages, ping/pong and control frames, and built-in OpenSSL (`wss://`) support.
 
-The motivation behind the project is to have a portable WebSockets client
-library under a permissive license (MIT) which feels like a traditional socket
-API (blocking with optional timeout) which can also provide a foundation for
-some additional messaging features similar to (but lighter weight than) AMQP and
-MQTT.
+The library has two parts, built from completely different networking designs,
+each suited to its use case:
 
-The code compiles and runs on Linux, FreeBSD, NetBSD, OpenBSD, OS X,
-Illumos/Solaris and Windows. It is fully commented and well-documented.
-Furthermore, the code is under a permissive license (MIT) allowing its use in
-commercial (closed-source) applications. The build system (CMake) includes
-built-in support to for cross-compiling from Linux/BSD to Windows, provided
-MinGW compiler and tools are installed on the host system.
+- A **client-side** component designed for single connections that operates
+  synchronously (blocking with an optional timeout), feeling like a traditional
+  socket API. It uses the operating system's native `poll()` and requires no
+  additional libraries.
+- An optional **server-side** component designed for many concurrent
+  connections that operates asynchronously atop [`libuv`](https://libuv.org/),
+  with a worker-thread pool for processing.
 
-There are two parts to the library: a client-side component and an optional
-server-side component. The two are built from completely different networking
-designs, each suited to their particular use-cases. The client architecture is
-designed for single connections and operates synchronously, waiting for
-responses from the server. The server architecture is designed for many
-concurrent connections and operates asynchronously.
+On top of the client API there is also an optional **messaging** layer that adds
+a structured message format with JSON and MessagePack serialization — a small
+step toward AMQP/MQTT-style messaging without the heft.
 
-The client-side API is simple and flexible. Connections wait (block) for
-responses and can employ a timeout in which to take action if a response does
-not arrive in a timely manner (or at all). The API is threadsafe in so far as
-each connection must be maintained in its own thread. All global structures and
-common services (error-reporting and tracing) use thread-local variables. The
-API runs atop the native operating system’s networking facilities, using
-`poll()` and thus no additional libraries are required.
+### Why vws?
 
-The server-side API implements a non-blocking, multiplexing, multithreaded
-server atop [`libuv`](https://libuv.org/). The server consists of a main
-networking thread and a pool of worker threads that process the data. The
-networking thread runs the `libuv` loop to handle socket I/O and evenly
-distributes incoming data to the worker threads via a synchronized queue. The
-worker threads process the data and optionally send back replies via a separate
-queue. The server takes care of all the WebSocket protocol serialization and
-communication between the the network and worker threads. Developers only need
-to focus on the actual message processing logic to service incoming messages.
+- **Portable C** — compiles and runs on Linux, FreeBSD, NetBSD, OpenBSD, OS X,
+  Illumos/Solaris and Windows. The CMake build supports cross-compiling from
+  Linux/BSD to Windows with MinGW.
+- **MIT licensed** — usable in commercial, closed-source applications.
+- **Dual client/server** — a synchronous client and an asynchronous,
+  multithreaded server, with the server component entirely optional.
+- **Optional messaging layer** — JSON and MessagePack over the same connection.
+- **Hardened** — bounds and NULL guards on the wire-facing parser and a
+  frame-size cap to resist wire-reachable denial-of-service inputs.
 
-The requirement of `libuv` is what makes the server component optional. While
-`libuv` runs on every major operating system, it is not expected to be a
-requirement of this library, as its original intent was to provide client-side
-connections only. Thus if you want use the server-side API, you simply add a
-configuration switch `-DBUILD_SERVER=1` at build time to include the code
+## Quick Start
 
-## WebSockets Overview
+The fastest path to a working client and a working server. Both examples are
+complete, compilable programs; the fuller variants appear under
+[Usage](#usage).
 
-WebSockets significantly enhance the capabilities of web applications compared
-to standard HTTP or raw TCP connections. They enable real-time data exchange
-with reduced latency due to the persistent connection, making them ideal for
-applications like live chat, gaming, real-time trading, and live sports
-updates.
+### A minimal client
 
-Several large-scale applications and platforms utilize WebSockets today,
-including Slack, WhatsApp, and Facebook for real-time messaging. WebSockets are
-also integral to the functionality of collaborative coding platforms like
-Microsoft's Visual Studio Code Live Share. On the server-side, many popular
-software systems support WebSocket, including Node.js, Apache, and Nginx.
+This connects, sends a text message, waits for a reply, and disconnects.
 
-### Background
+```c
+// quickstart-client — minimal WebSocket client (subset of client-basic)
+#include <vws/websocket.h>
+#include <stdio.h>
 
-WebSockets emerged in the late 2000’s in response to the growing need for
-real-time, bidirectional communication in web applications. The goal was to
-provide a standardized way for web servers to send content to browsers without
-being prompted by the user, and vice versa. In December 2011 they were
-standardized by the Internet Engineering Task Force (IETF) in [RFC
-6455](https://www.rfc-editor.org/rfc/rfc6455.html). They now enjoy wide support
-and integration in modern browsers, smartphones, IoT devices and server
-software. They have become a fundamental technology in modern web applications.
+int main(int argc, const char* argv[])
+{
+    // Create a connection object
+    vws_cnx* cnx = vws_cnx_new();
 
-### Concepts and Operation
+    // Connect. TLS is used automatically if the "wss" scheme is given.
+    if (vws_connect(cnx, "ws://localhost:8181/websocket") == false)
+    {
+        printf("Failed to connect\n");
+        vws_cnx_free(cnx);
+        return 1;
+    }
+
+    // Send a TEXT frame
+    vws_frame_send_text(cnx, "Hello, world!");
+
+    // Receive a message (returns NULL on timeout)
+    vws_msg* reply = vws_msg_recv(cnx);
+    if (reply != NULL)
+    {
+        printf("Received %zu bytes\n", reply->data->size);
+        vws_msg_free(reply);
+    }
+
+    vws_disconnect(cnx);
+    vws_cnx_free(cnx);
+
+    return 0;
+}
+```
+
+### A minimal WebSocket echo server
+
+> **Before you begin:** the server component requires `libuv` and is built only
+> when `BUILD_SERVER` is enabled (the default). See [Installation](#installation).
+
+This accepts connections and echoes each message back.
+
+```c
+// quickstart-server — minimal WebSocket echo server (subset of server-ws)
+#include <vws/server.h>
+
+// Runs in the context of a worker thread. Assigned to the derived process_ws
+// hook (on_msg_in is the framework's internal dispatcher — do not overwrite it).
+void echo(vws_svr* s, vws_cid_t cid, vws_msg* m, void* ctx)
+{
+    // Echo the message back, preserving its opcode (TEXT/BINARY)
+    vws_msg* reply = vws_msg_new();
+    reply->opcode  = m->opcode;
+    vws_buffer_append(reply->data, m->data->data, m->data->size);
+
+    // send() takes ownership of the reply; we free the incoming message
+    s->send(s, cid, reply, NULL);
+    vws_msg_free(m);
+}
+
+int main(int argc, const char* argv[])
+{
+    vws_svr* server    = vws_svr_new(10, 0, 0);
+    server->process_ws = echo;
+
+    // Run (blocks until the server is stopped)
+    vws_svr_run(server, "127.0.0.1", 8181);
+
+    // Stop via the base type, then free and clean up
+    vws_tcp_svr_stop((vws_tcp_svr*)server);
+    vws_svr_free(server);
+    vws_cleanup();
+
+    return 0;
+}
+```
+
+To see the library exercised end-to-end, build the project and step into the
+`src/test` directory: run `./server` to start a simple WebSocket server, then run
+`test_websocket`.
+
+## Concepts
 
 Unlike traditional HTTP connections, which are stateless and unidirectional,
-WebSocket connections are stateful and bidirectional. The connection is
-established through an HTTP handshake (HTTP Upgrade request), which is then
-upgraded to a WebSocket connection if the server supports it. The connection
-remains open until explicitly closed, enabling low-latency data exchange.
+WebSocket connections are stateful and bidirectional. A connection is
+established through an HTTP handshake (an HTTP Upgrade request), then upgraded to
+a WebSocket connection if the server supports it, and remains open until
+explicitly closed.
 
-The WebSockets protocol communicates through a series of data units called
-frames. Each WebSocket frame has a maximum size of 2^64 bytes (but the actual
-size limit may be smaller due to network or system constraints). There are
-several types of frames, including text frames, binary frames, continuation
-frames, and control frames.
+The protocol communicates through data units called **frames**. The protocol
+permits a frame payload of up to 2^64 bytes, though the effective limit is
+usually smaller due to network or system constraints. In addition, this library
+caps a single frame at **64 MiB** (`VWS_MAX_FRAME_SIZE`): a frame whose payload
+length exceeds that is rejected as a `FRAME_ERROR`. The cap is a compile-time
+tunable defined in `src/websocket.c`.
 
-Text frames contain Unicode text data, while binary frames carry binary
-data. Continuation frames allow for larger messages to be broken down into
-smaller chunks. Control frames handle protocol-level interactions and include
-close frames, ping frames, and pong frames. The close frame is used to terminate
-a connection, ping frames are for checking the liveness of the connection, and
-pong frames are responses to ping frames.
+While frames are the unit on the wire, applications generally work in terms of
+**messages** — one or more frames terminated by a frame with the `FIN` bit set.
+The deeper frame taxonomy (opcodes, masking, control frames) is covered under
+[Advanced Topics](#advanced-topics). For the full reference, see the
+[online documentation](https://vrtql.github.io/ws/ws.html).
 
 ## Usage
 
-For working examples beyond that shown here, see the `test_websocket.c` file in
-the `src/test` directory. After building the project, step into that directory
-and run `./server` which starts a simple websocket server. Then run
-`test_websocket`.
+The examples below are each complete, standalone programs. They progress from
+the synchronous client API, through the optional messaging layer, to the
+asynchronous server API.
 
 ### Client API
 
-The WebSockets API is built solely upon WebSockets constructs: frames, messages
-and connections, as you would expect. It intuitively follows the concepts and
-structure laid out in the standard. The following is a basic example of the
-Websockets API:
+The client API is built solely on WebSocket constructs — frames, messages and
+connections. The connection object (`vws_cnx`) embeds a `vws_socket` as its first
+member, which is why socket-level calls such as `vws_socket_set_timeout()` and
+`vws_socket_is_connected()` take the connection cast to `(vws_socket*)`.
 
 ```c
+// client-basic — synchronous WebSocket client
 #include <vws/websocket.h>
+#include <stdio.h>
+#include <assert.h>
 
 int main(int argc, const char* argv[])
 {
@@ -124,7 +175,7 @@ int main(int argc, const char* argv[])
     // both to connect() and to read operations (i.e. poll()).
     vws_socket_set_timeout((vws_socket*)cnx, 2);
 
-    // Connect. This will automatically use SSL if "wss" scheme is used.
+    // Connect. This will automatically use SSL if the "wss" scheme is used.
     cstr uri = "ws://localhost:8181/websocket";
     if (vws_connect(cnx, uri) == false)
     {
@@ -133,47 +184,35 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
-    // Can check connection state this way. Should always be true here as we
-    // just successfully connected.
+    // Check connection state. Should be true here as we just connected.
     assert(vws_socket_is_connected((vws_socket*)cnx) == true);
 
-    // Enable tracing. This will dump frames to the console in human-readable
+    // Enable tracing. This dumps frames to the console in human-readable
     // format as they are sent and received.
     vws.tracelevel = VT_PROTOCOL;
 
     // Send a TEXT frame
     vws_frame_send_text(cnx, "Hello, world!");
 
-    // Receive websocket message
+    // Receive a websocket message (NULL on timeout)
     vws_msg* reply = vws_msg_recv(cnx);
-
-    if (reply == NULL)
+    if (reply != NULL)
     {
-        // There was no message received and it resulted in timeout
-    }
-    else
-    {
-        // Free message
         vws_msg_free(reply);
     }
 
     // Send a BINARY message
     vws_msg_send_binary(cnx, (ucstr)"Hello, world!", 14);
 
-    // Receive websocket message
+    // Receive a websocket message (NULL on timeout)
     reply = vws_msg_recv(cnx);
-
-    if (reply == NULL)
+    if (reply != NULL)
     {
-        // There was no message received and it resulted in timeout
-    }
-    else
-    {
-        // Free message
         vws_msg_free(reply);
     }
 
     vws_disconnect(cnx);
+    vws_cnx_free(cnx);
 
     return 0;
 }
@@ -181,40 +220,26 @@ int main(int argc, const char* argv[])
 
 ### Messaging API
 
-The Messaging API is built on top of the WebSockets API. While WebSockets
-provide a mechanism for real-time bidirectional communication, it doesn't
-inherently offer things like you would see in more heavyweight message protocols
-like AMQP. The Messaging API provides a small step in that direction, but
-without the heft. It mainly provides a more structured message format with
-built-in serialization. The message structure includes two maps (hashtables of
-string key/value pairs) and a payload. One map, called `routing`, is designed to
-hold routing information for messaging applications. The other map, called
-`headers`, is for application use. The payload can hold both text and binary
-data.
-
-The message structure operates with a higher-level connection API which works
-atop the native WebSocket API. The connection API mainly adds support to send
-and receive the messages, automatically handling serialization and
-deserialization on and off the wire. It really just boils down to `send()` and
-`receive()` calls which operate with these messages.
-
-Messages can be serialized in two formats: JSON and MessagePack. Both formats
-can be sent over the same connection on a message-by-message basis. That is, the
-connection is able to auto-detect each incoming message's format and deserialize
-accordingly. Thus connections support mixed-content messages: JSON and
-MessagePack.
-
-The following is a basic example of using the high-level messaging API.
+The messaging API is built on top of the client API. WebSockets provide
+real-time bidirectional communication but do not, by themselves, offer the
+structure of heavier protocols like AMQP. The messaging layer adds a structured
+message (`vrtql_msg`) with two string maps — `routing` (for routing information)
+and `headers` (for application use) — plus a payload that can hold text or
+binary data. It handles serialization automatically and can auto-detect each
+incoming message's format, so JSON and MessagePack can be mixed on the same
+connection.
 
 ```c
+// client-message — structured messaging over a WebSocket connection
 #include <vws/message.h>
+#include <stdio.h>
 
-int main()
+int main(int argc, const char* argv[])
 {
     // Create connection object
     vws_cnx* cnx = vws_cnx_new();
 
-    // Connect. This will automatically use SSL if "wss" scheme is used.
+    // Connect. This will automatically use SSL if the "wss" scheme is used.
     cstr uri = "ws://localhost:8181/websocket";
     if (vws_connect(cnx, uri) == false)
     {
@@ -223,18 +248,16 @@ int main()
         return 1;
     }
 
-    // Enable tracing. This will dump frames to the console in human-readable
-    // format as they are sent and received.
+    // Enable tracing
     vws.tracelevel = VT_PROTOCOL;
 
-    // Create
+    // Create a message
     vrtql_msg* request = vrtql_msg_new();
-
     vrtql_msg_set_routing(request, "key", "value");
     vrtql_msg_set_header(request, "key", "value");
     vrtql_msg_set_content(request, "payload");
 
-    // Send
+    // Send (returns < 0 on error)
     if (vrtql_msg_send(cnx, request) < 0)
     {
         printf("Failed to send: %s\n", vws.e.text);
@@ -243,26 +266,16 @@ int main()
         return 1;
     }
 
-    // Receive
+    // Receive (NULL on timeout)
     vrtql_msg* reply = vrtql_msg_recv(cnx);
-
-    if (reply == NULL)
+    if (reply != NULL)
     {
-        // There was no message received and it resulted in timeout
-    }
-    else
-    {
-        // Free message
         vrtql_msg_free(reply);
     }
 
     // Cleanup
     vrtql_msg_free(request);
-
-    // Diconnect
     vws_disconnect(cnx);
-
-    // Free the connection
     vws_cnx_free(cnx);
 
     return 0;
@@ -271,54 +284,51 @@ int main()
 
 ### Server API
 
-The server API is layered and works the same for all media formats: binary data,
-WebSockets, HTTP and VRTQL messages. Once you understand how the basic API
-works, everything else is intuitive. The API is simple and designed to make it
-very easy for you to focus on processing messages. There are only a few steps
-required to create a server. You create a server instance, define a processing
-function to handle incoming data, and send data back to the remote peer. We will
-take each of these in turn.
+The server API is layered and works the same way across media formats: raw
+binary data, WebSocket messages, HTTP requests, and VRTQL messages. There are
+only a few steps to create a server: you create a server instance, define a
+processing function for incoming data, and send data back to the peer.
 
-You create a server instance using the `vrtql_svr_new()` function. This takes
-three arguments: the number of worker threads, the connection backlog, and the
-maximum message queue size. If you set the latter two arguments to zero, it will
-use the default values. Next, you create a processing function. The signature of
-this function varies according to the server. For the core server, which deals
-with unstructured data, this signature is given by the `vrtql_svr_process_data`
-callback. It takes a two arguments. The first argument is a `vrtql_svr_data`
-instance, created on the heap, which simply holds a blob of data. It is up to
-your processing function to make sense of that data and respond accordingly.
+**The model.** Every server is created with a `*_svr_new(pool_size, backlog,
+queue_size)` call:
 
-The second argument is the worker thread context, which allows you to create
-application-specific envrionment for processing. Since the server uses a thread
-pool of worker threads for processing, you may want to have some context or
-environment for your processing available. This is the job of the `worker_ctor`,
-`worker_ctor_data` and `worker_dtor` members. The `worker_ctor` constructs the
-user-defined context which is passed into the processing function as the last
-argument. The `worker_ctor_data` is user-defined data passed into the
-`worker_ctor` function to assist setting up the environment. Finally the
-`worker_dtor` is called on worker thread shutdown and passed the context
-returned by `worker_ctor` for cleanup. All of these are optional, but if you
-have any processing that requires things like dedicated database connections or
-other environmental resources specific to the thread envrionment, they can be
-very useful.
+- `pool_size` — the number of worker threads in the processing pool.
+- `backlog` — the `listen()` connection backlog; `0` selects the default (128).
+- `queue_size` — the maximum request/response queue size; `0` selects the
+  default (1024).
 
-If you need to send data back to the peer, you do so using
-`vrtql_svr_send()`. With all these things in place, you call `vrtql_svr_run()`
-to start the server.
+The three server types are layered on one another: `vws_svr` (WebSocket) embeds
+`vws_tcp_svr` (core) as its first member, and `vrtql_msg_svr` (messaging) embeds
+`vws_svr`. Base operations such as `vws_tcp_svr_stop()` take a `vws_tcp_svr*`, so
+the derived servers are cast with `(vws_tcp_svr*)` when stopped. The
+type-specific calls — `vws_svr_run()`, `vrtql_msg_svr_run()`, and so on — take
+the derived type directly.
 
-The following illustrates writing a basic echo server:
+#### Core server (unstructured data)
+
+The core server (`vws_tcp_svr`) deals in unstructured blobs. Its processing
+callback (`vws_tcp_svr_process_data`) takes two arguments: the `vws_svr_data`
+instance (a blob of data, allocated on the heap), and the worker thread context.
+
+The worker context is built by the optional `worker_ctor`, `worker_ctor_data`
+and `worker_dtor` members. `worker_ctor` constructs a per-thread context that is
+passed into the processing function as its last argument; `worker_ctor_data` is
+user data passed into `worker_ctor`; and `worker_dtor` is called on worker
+shutdown to clean the context up. These are ideal for per-thread resources such
+as dedicated database connections.
 
 ```c
+// server-core — echo server over the unstructured (TCP) server
 #include <vws/server.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
 
 cstr server_host = "127.0.0.1";
 int  server_port = 8181;
 
-/* Stuff you want allocated in every worker thread for you to do your
-** application-specific processing.
-*/
-type struct my_env
+/* Anything you want allocated per worker thread for your processing. */
+typedef struct my_env
 {
     void* thingy;
 } my_env;
@@ -341,39 +351,33 @@ void process(vws_svr_data* req, void* ctx)
     strncpy(data, req->data, req->size);
 
     // Create response
-    vws_svr_data* reply;
-
-    reply = vws_svr_data_own(req->server, req->cid, (ucstr)data, req->size);
+    vws_svr_data* reply = vws_svr_data_own(server, req->cid, (ucstr)data, req->size);
 
     // Free request
     vws_svr_data_free(req);
 
     if (vws.tracelevel >= VT_APPLICATION)
     {
-        vws.trace(VL_INFO, "process(%lu): %i bytes", reply->cid, reply->size);
+        vws.trace(VL_INFO, "process(cid=%" PRId64 "): %zu bytes",
+                  reply->cid.key, reply->size);
     }
 
-    // Send reply. This will wakeup network thread.
+    // Send reply. This will wake up the network thread.
     vws_tcp_svr_send(reply);
 }
 
-// Allocate context for worker thread
+// Allocate context for a worker thread
 void* worker_thread_startup(void* data)
 {
-    // Worker thread specific initialization
-
-    vrtql_svr* server = (vrtql_svr*)data;
     my_env* env = (my_env*)malloc(sizeof(my_env));
     env->thingy = malloc(1);
 
     return env;
 }
 
-// Deallocate context for worker thread
+// Deallocate context for a worker thread
 void worker_thread_shutdown(void* data)
 {
-    // Worker thread specific cleanup
-
     my_env* env = (my_env*)data;
     free(env->thingy);
     free(env);
@@ -383,99 +387,108 @@ int main(int argc, const char* argv[])
 {
     // Run server with 10 worker threads, default TCP listen backlog (128) and
     // default work queue size (1024 pending requests).
-    vrtql_svr* server  = vrtql_svr_new(10, 0, 0);
-    server->on_data_in = process;
-    vws.tracelevel     = VT_THREAD;
+    vws_tcp_svr* server = vws_tcp_svr_new(10, 0, 0);
+    server->on_data_in  = process;
+    vws.tracelevel      = VT_THREAD;
 
     // Worker thread context
     server->worker_ctor      = worker_thread_startup;
     server->worker_ctor_data = server;
     server->worker_dtor      = worker_thread_shutdown;
 
-    // Run
-    vrtql_svr_run(server, server_host, server_port);
+    // Run (blocks until vws_tcp_svr_stop() is called)
+    vws_tcp_svr_run(server, server_host, server_port);
 
     // Shutdown
-    vrtql_svr_stop(server);
-    uv_thread_join(&server_tid);
-    vrtql_svr_free(server);
+    vws_tcp_svr_stop(server);
+    vws_tcp_svr_free(server);
+    vws_cleanup();
+
+    return 0;
 }
 ```
 
-Writing a WebSocket server is even simpler. It follows the same pattern but uses
-`vws_svr_new()` to create the server. The processing function signature is given
-by the `vws_svr_process_msg` callback. Rather than using unstructured data, it
-operates on WebSocket messages.
+#### WebSocket server (delta from core)
 
-The following illustrates writing a WebSocket server:
+Writing a WebSocket server is the same pattern with two changes: create it with
+`vws_svr_new()`, and set the `process_ws` callback (`vws_svr_process_msg`), which
+operates on WebSocket messages (`vws_msg`) rather than raw data. (Set your
+handler on `process_ws`, not `on_msg_in` — the latter is the framework's internal
+dispatcher, which calls your `process_ws`.)
 
 ```c
+// server-ws — WebSocket echo server
 #include <vws/server.h>
+#include <inttypes.h>
 
 cstr server_host = "127.0.0.1";
 int  server_port = 8181;
 
-// Server function to process messages. Runs in context of worker thread.
+// Process messages. Runs in the context of a worker thread.
 void process(vws_svr* s, vws_cid_t cid, vws_msg* m, void* ctx)
 {
-    vws.trace(VL_INFO, "process_message (%ul) %p", cid, m);
+    vws.trace(VL_INFO, "process (cid=%" PRId64 ") %p", cid.key, m);
 
-    // Echo back. Note: You should always set reply messages format to the
-    // format of the connection.
+    // Echo back. Note: always set the reply's format to that of the connection.
 
     // Create reply message
     vws_msg* reply = vws_msg_new();
 
-    // Use same format
+    // Use the same format/opcode
     reply->opcode = m->opcode;
 
     // Copy content
     vws_buffer_append(reply->data, m->data->data, m->data->size);
 
-    // Send. We don't free message as send() does it for us.
+    // Send. We don't free the reply; send() does it for us.
     s->send(s, cid, reply, NULL);
 
-    // Clean up request
+    // Clean up the request
     vws_msg_free(m);
 }
 
 int main(int argc, const char* argv[])
 {
     // Setup
-    vws_svr* server = vws_svr_new(10, 0, 0);
-    server->process = process;
+    vws_svr* server    = vws_svr_new(10, 0, 0);
+    server->process_ws = process;
 
-    // Run
-    vrtql_tcp_svr_run((vrtql_svr*)server, server_host, server_port);
+    // Run (blocks until stopped)
+    vws_svr_run(server, server_host, server_port);
 
-    // Shutdown
-    vrtql_svr_stop((vrtql_svr*)server);
-    uv_thread_join(&server_tid);
+    // Shutdown — stop takes the base type
+    vws_tcp_svr_stop((vws_tcp_svr*)server);
     vws_svr_free(server);
     vws_cleanup();
+
+    return 0;
 }
 ```
 
-Additionally, the framework includes operating as a pure HTTP server. If HTTP
-requests come in which are not WebSocket upgrades, the framework will attempt to
-pass the request to a user-defined handler `process_http`. If this is defined
-then that callback will be invoked with the HTTP request passed to it. The
-following is an example of running a pure HTTP server.
+#### HTTP handler (delta)
+
+The framework can also serve plain HTTP. If an incoming HTTP request is not a
+WebSocket upgrade, the framework passes it to a user-defined `process_http`
+callback (`vws_svr_process_http_req`) if one is set. This can run in tandem with
+the WebSocket server.
 
 ```c
+// server-http — pure HTTP handler
 #include <vws/server.h>
+#include <string.h>
+#include <inttypes.h>
 
 cstr server_host = "127.0.0.1";
 int  server_port = 8181;
 
-// Server function to process HTTP messages. Runs in context of worker thread.
+// Process HTTP requests. Runs in the context of a worker thread.
 bool process(vws_svr* s, vws_cid_t cid, vws_http_msg* msg, void* ctx)
 {
     vws_tcp_svr* server = (vws_tcp_svr*)s;
 
     if (vws.tracelevel >= VT_APPLICATION)
     {
-        vws.trace(VL_INFO, "server: process (%ul) %p", cid, msg);
+        vws.trace(VL_INFO, "process (cid=%" PRId64 ") %p", cid.key, msg);
     }
 
     cstr response = "HTTP/1.1 200 OK\r\n"
@@ -490,7 +503,7 @@ bool process(vws_svr* s, vws_cid_t cid, vws_http_msg* msg, void* ctx)
     // Create response
     vws_svr_data* reply = vws_svr_data_own(server, cid, (ucstr)data, strlen(data));
 
-    // Send reply. This will wakeup network thread.
+    // Send reply. This will wake up the network thread.
     vws_tcp_svr_send(reply);
 
     return true;
@@ -499,58 +512,56 @@ bool process(vws_svr* s, vws_cid_t cid, vws_http_msg* msg, void* ctx)
 int main(int argc, const char* argv[])
 {
     // Setup
-    vws_svr* server = vws_svr_new(10, 0, 0);
+    vws_svr* server      = vws_svr_new(10, 0, 0);
     server->process_http = process;
 
-    // Run
-    vrtql_tcp_svr_run((vrtql_svr*)server, server_host, server_port);
+    // Run (blocks until stopped)
+    vws_svr_run(server, server_host, server_port);
 
     // Shutdown
-    vrtql_svr_stop((vrtql_svr*)server);
-    uv_thread_join(&server_tid);
+    vws_tcp_svr_stop((vws_tcp_svr*)server);
     vws_svr_free(server);
     vws_cleanup();
+
+    return 0;
 }
 ```
 
-This can run in tandem with the WebSocket server as well. As long as you provide
-the appropriate callbacks, the framework will call the corresponding callback
-based on the context.
+#### Message server (delta)
 
-Finally, the Message API server works in exactly the same way. The only
-difference is that it operates on `vrtql_msg` messages.
-
-The following illustrates creating a Message server:
+The messaging server works the same way, operating on `vrtql_msg` messages.
 
 ```c
+// server-message — VRTQL messaging echo server
 #include <vws/server.h>
+#include <inttypes.h>
 
 cstr server_host = "127.0.0.1";
 int  server_port = 8181;
 
-// Server function to process messages. Runs in context of worker thread.
+// Process messages. Runs in the context of a worker thread.
 void process(vws_svr* s, vws_cid_t cid, vrtql_msg* m, void* ctx)
 {
     vrtql_msg_svr* server = (vrtql_msg_svr*)s;
 
-    vws.trace(VL_INFO, "process (%lu) %p", cid, m);
+    vws.trace(VL_INFO, "process (cid=%" PRId64 ") %p", cid.key, m);
 
-    // Echo back. Note: You should always set reply messages format to the
-    // format of the connection.
+    // Echo back. Note: always set the reply's format to that of the connection.
 
     // Create reply message
     vrtql_msg* reply = vrtql_msg_new();
     reply->format    = m->format;
 
     // Copy content
-    ucstr data  = m->content->data;
+    ucstr  data = m->content->data;
     size_t size = m->content->size;
     vws_buffer_append(reply->content, data, size);
 
-    // Send. We don't free message as send() does it for us.
+    // Send via the derived type (reply is a vrtql_msg). We don't free the
+    // reply; send() does it for us.
     server->send(s, cid, reply, NULL);
 
-    // Clean up request
+    // Clean up the request
     vrtql_msg_free(m);
 }
 
@@ -560,42 +571,137 @@ int main(int argc, const char* argv[])
     vrtql_msg_svr* server = vrtql_msg_svr_new(10, 0, 0);
     server->process       = process;
 
-    // Run
-    vrtql_svr_run((vrtql_svr*)server, server_host, server_port);
+    // Run (blocks until stopped)
+    vrtql_msg_svr_run(server, server_host, server_port);
 
     // Shutdown
-    vrtql_svr_stop((vrtql_svr*)server);
-    uv_thread_join(&server_tid);
+    vws_tcp_svr_stop((vws_tcp_svr*)server);
     vrtql_msg_svr_free(server);
     vws_cleanup();
+
+    return 0;
 }
 ```
 
-## Documentation
+## Error Handling
 
-Full documentation is located [here](https://vrtql.github.io/ws/ws.html). Source
-code annotation is located [here](https://vrtql.github.io/ws-code-doc/root/).
+Error and tracing state live in a single thread-local global, `vws` (of type
+`vws_env`). Because it is thread-local, each thread has its own independent copy
+— consistent with the rule that each client connection is used only from the
+thread that created it.
 
-## Feature Summary
+After a call fails, inspect `vws.e`, a `vws_error_value` with a numeric `code`
+and a human-readable `text`:
 
-- Written in C for maximum portability
-- Runs on all major operating systems
-- OpenSSL support built in
-- Thread safe
-- Liberal license allowing use in closed-source applications
-- Simple, intuitive API.
-- Handles complicated tasks like socket-upgrade on connection, PING requests,
-  proper shutdown, frame formatting/masking, message sending and receiving.
-- Well tested with extensive unit tests
-- Well documented
-- Provides a high-level API for messaging applications supporing both JSON and
-  MessagePack serialization formats within same connection.
-- Includes native Ruby C extension with RDoc documentaiton.
+```c
+// vws.e.code is a uint64_t; printing it portably needs <inttypes.h> (PRIu64).
+if (vws_connect(cnx, "ws://localhost:8181/websocket") == false)
+{
+    fprintf(stderr, "connect failed: [%" PRIu64 "] %s\n", vws.e.code, vws.e.text);
+    vws_cnx_free(cnx);
+    return 1;
+}
+```
+
+The error codes are the `vws_error_code_t` values: `VE_SUCCESS`, `VE_TIMEOUT`,
+`VE_WARN`, `VE_SOCKET`, `VE_SEND`, `VE_RECV`, `VE_SYS`, `VE_RT`, `VE_MEM` and
+`VE_FATAL`.
+
+**Return-value conventions.** The send functions (for example
+`vws_frame_send_text()`, `vws_msg_send_binary()` and `vrtql_msg_send()`) return
+an `ssize_t` and yield `-1` on error. The receive functions (`vws_msg_recv()`,
+`vrtql_msg_recv()`) return `NULL` on timeout or error. `vws_connect()` returns a
+`bool`.
+
+**Tracing.** Set `vws.tracelevel` to a `vws_tl_t` value to control how much is
+logged: `VT_OFF`, `VT_APPLICATION`, `VT_MODULE`, `VT_SERVICE`, `VT_PROTOCOL`,
+`VT_THREAD`, `VT_TCPIP`, `VT_LOCK`, `VT_MEMORY` or `VT_ALL`. At `VT_PROTOCOL` and
+above, frames are dumped to the console in human-readable form as they are sent
+and received. Emit your own trace lines with `vws.trace(level, fmt, ...)`, where
+`level` is a `vws_log_level_t` severity: `VL_DEBUG`, `VL_INFO`, `VL_WARN` or
+`VL_ERROR`.
+
+## Threading Model
+
+**Client.** The client API is synchronous and thread-affine: maintain each
+`vws_cnx` in its own thread and do not share a connection across threads. All
+common services (error reporting and tracing) use the thread-local `vws` global,
+so each thread carries its own error and trace state.
+
+**Server.** The server runs one main networking thread plus a pool of
+`pool_size` worker threads. The networking thread runs the `libuv` loop, handles
+all socket I/O, and distributes incoming data to the workers over a synchronized
+queue; workers process the data and return replies over a separate queue. The
+framework handles all WebSocket protocol serialization between the network and
+worker threads, so your processing function only needs to service the message.
+
+Per-worker state is established through `worker_ctor` / `worker_ctor_data` /
+`worker_dtor` (see the [core server example](#core-server-unstructured-data)).
+Use the per-worker context for resources that should not be shared across
+threads — for instance a dedicated database handle per worker.
+
+## TLS / SSL
+
+TLS is enabled automatically when a connection URI uses the `wss://` scheme; it
+runs over the library's global OpenSSL context, `vws_ssl_ctx` (an `SSL_CTX*`).
+OpenSSL is a build dependency.
+
+This version exposes **no public API** for certificate configuration,
+verification policy, or supplying a custom SSL context — `wss://` simply enables
+TLS through the built-in context. For Windows builds, OpenSSL must be cross-built
+and made available to the toolchain (see
+[Cross-Compiling for Windows](#cross-compiling-for-windows)).
+
+## Lifecycle and Teardown
+
+**Client:**
+
+```
+vws_cnx_new()  →  vws_connect()  →  … send/recv …  →  vws_disconnect()  →  vws_cnx_free()
+```
+
+**Server:**
+
+```
+*_svr_new()  →  set callbacks / worker context  →  *_svr_run()   [blocks until stopped]
+             →  vws_tcp_svr_stop((vws_tcp_svr*)server)  →  *_svr_free()  →  vws_cleanup()
+```
+
+`*_svr_run()` blocks until the server is stopped. Stop a WebSocket or message
+server by casting it to the base type:
+`vws_tcp_svr_stop((vws_tcp_svr*)server)` — there is no `vws_svr_stop` or
+`vrtql_msg_svr_stop`. Call `vws_cleanup()` once at process exit to release
+global resources.
+
+## Advanced Topics
+
+### Experimental async reactor
+
+The library additionally includes an experimental, non-blocking,
+single-connection asynchronous reactor (`src/async.h`) for client-side use
+without `libuv` — a scaled-down, `poll()`-driven slice of the server's loop. It
+is currently low-level foundation; its ergonomic public API arrives with a
+forthcoming C++ `Channel` wrapper and will be documented then. It is not yet part
+of the supported public API.
+
+### Frame taxonomy
+
+On the wire, a message is a sequence of frames. The first frame of a message
+carries its type (`TEXT` or `BINARY`); subsequent frames are `CONTINUATION`
+frames, allowing a large message to be split into smaller chunks. The final
+frame of a message has the `FIN` bit set. Control frames handle protocol-level
+interactions: `CLOSE` terminates a connection, `PING` checks liveness, and
+`PONG` answers a ping. Text frames carry Unicode text; binary frames carry
+arbitrary bytes.
+
+As noted under [Concepts](#concepts), the library rejects any single frame whose
+payload exceeds `VWS_MAX_FRAME_SIZE` (64 MiB) as a `FRAME_ERROR`, before
+allocating memory for it; the cap is a compile-time `#define` in
+`src/websocket.c`.
 
 ## Installation
 
-In order to build the code you need CMake version 3.0 or higher on your
-system.
+To build the code you need CMake version 3.15 or higher.
 
 ### C Library
 
@@ -608,11 +714,23 @@ $ cmake .
 $ make
 $ sudo make install
 ```
-Consider deactivating or activating the server side API, depending on your use case:
+
+To build without the server-side API (and drop the `libuv` dependency):
+
 ```bash
 $ cmake . -DBUILD_SERVER=0
 ```
-(instead of previous `cmake .` command)
+
+The build recognizes these options (each passed as `-D<NAME>=<VALUE>` to
+`cmake`):
+
+- `BUILD_SERVER` (default `ON`) — build the optional server component. It
+  requires **libuv** (`find_package(LibUV REQUIRED)`); install your platform's
+  `libuv` development package (for example, `apt-get install libuv1-dev`)
+  before building with the server enabled.
+- `ASAN` (default `OFF`) — build with AddressSanitizer.
+- `VWS_TSAN` (default `OFF`) — build the library and tests with ThreadSanitizer
+  for race detection.
 
 ### Ruby Gem
 
@@ -636,7 +754,7 @@ Alternately, without using `gem`:
     make install
 ```
 
-The RDoc documentaton is located [here](https://vrtql.github.io/ws/ruby/).
+The RDoc documentation is located [here](https://vrtql.github.io/ws/ruby/).
 
 ### Cross-Compiling for Windows
 
@@ -650,7 +768,9 @@ $ apt-get install mingw-w64 mingw-w64-tools mingw-w64-common \
 
 You will need to have OpenSSL for Windows on your system as well. If you don't
 have it you can build as follows. First download the version you want to
-build. Here we will use `openssl-1.1.1u.tar.gz` as an example. Create the
+build. Here we will use `openssl-1.1.1u.tar.gz` as an example. (The OpenSSL
+`1.1.1` series has reached end of life; for new builds prefer a current
+OpenSSL 3.x release and substitute the version accordingly.) Create the
 install directory you intend to put OpenSSL in. For example:
 
 ```bash
@@ -679,11 +799,47 @@ full path). Then invoke CMake as follows:
 $ cmake -DCMAKE_TOOLCHAIN_FILE=config/windows-toolchain.cmake
 ```
 
-Then build as normal
+Then build as normal:
 
 ```bash
 $ make
 ```
+
+## Compatibility
+
+| Aspect             | Support                                                              |
+|--------------------|---------------------------------------------------------------------|
+| Version            | 2.0.0                                                                |
+| Operating systems  | Linux, FreeBSD, NetBSD, OpenBSD, OS X, Illumos/Solaris, Windows      |
+| Build system       | CMake ≥ 3.15                                                         |
+| Language standard  | C11 (uses C11 atomics)                                               |
+| Compilers          | GCC, Clang; MinGW-w64 for Windows cross-compilation                  |
+| Server dependency  | libuv (only when `BUILD_SERVER=ON`)                                  |
+| TLS                | OpenSSL (via the `wss://` scheme)                                    |
+| Bindings           | Ruby C extension                                                     |
+
+## Documentation
+
+Full documentation is located [here](https://vrtql.github.io/ws/ws.html). Source
+code annotation is located [here](https://vrtql.github.io/ws-code-doc/root/).
+
+## Feature Summary
+
+- Written in C for maximum portability
+- Runs on all major operating systems
+- OpenSSL support built in
+- Thread safe
+- Liberal license allowing use in closed-source applications
+- Simple, intuitive API.
+- Handles complicated tasks like socket-upgrade on connection, PING requests,
+  proper shutdown, frame formatting/masking, message sending and receiving.
+- Well tested with extensive unit tests, including a ThreadSanitizer race suite
+- Hardened against wire-reachable denial-of-service inputs (frame-size cap,
+  parser bounds and NULL guards)
+- Well documented
+- Provides a high-level API for messaging applications supporting both JSON and
+  MessagePack serialization formats within the same connection.
+- Includes native Ruby C extension with RDoc documentation.
 
 ## Contributing
 


### PR DESCRIPTION
Restructures the README toward an easier onboarding path and corrects the post-rework server API in the examples (wp-authored, wp3 accuracy-reviewed against the headers).

- **Server examples corrected** to the real callback model: `on_msg_in`/`on_data_in`, layered `new`/`run`, stop via the `(vws_tcp_svr*)` cast (verified vs `server.h:905` `process_ws` / `:982` `process` + `test_ws_server.c`/`test_msg_server.c`/`test_http_server.c`).
- **`cid`/status formatting** uses `inttypes` (`PRId64`/`PRIu64`); no leftover `%ld`/`%lu`.
- Adds the 64 MiB frame-size cap, the experimental async-reactor note, build options, and a high-level change summary.
- **Header-verified, no invented APIs**: `VWS_MAX_FRAME_SIZE` is an internal cap (not a public macro), there is no public TLS-cert API, and `vws_svr_stop` does not exist.

The DocBook example walk-through Part is a **separate** upcoming changeset (it pins + fetches the websockets-examples source). This PR is README.md only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)