### PR TITLE
Win64: cross-compile the server component (BUILD_SERVER=1)

### DIFF
--- a/config/windows-toolchain.cmake
+++ b/config/windows-toolchain.cmake
@@ -18,6 +18,17 @@
 #    make
 #    make DESTDIR=/opt/mingw install
 #
+# 2b. Build libuv (only needed for BUILD_SERVER=1)
+#
+#    git clone --depth 1 --branch v1.40.0 \
+#        https://github.com/libuv/libuv.git
+#    cd libuv
+#    cmake -B build-mingw -G "Unix Makefiles" \
+#          -DCMAKE_TOOLCHAIN_FILE=<vws>/config/windows-toolchain.cmake \
+#          -DCMAKE_INSTALL_PREFIX=/opt/mingw/libuv \
+#          -DBUILD_TESTING=OFF -DLIBUV_BUILD_TESTS=OFF
+#    make -C build-mingw install
+#
 # 3. Invoke CMake
 #
 #   cmake -DCMAKE_TOOLCHAIN_FILE=config/windows-toolchain.cmake
@@ -31,8 +42,9 @@ set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
 set(CMAKE_Fortran_COMPILER ${TOOLCHAIN_PREFIX}-gfortran)
 set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
 
-# Set to where you have it installed
-set(CMAKE_FIND_ROOT_PATH "/opt/mingw/openssl")
+# Set to where you have it installed. libuv is only required for
+# BUILD_SERVER=1; the openssl prefix alone suffices for the client core.
+set(CMAKE_FIND_ROOT_PATH "/opt/mingw/openssl" "/opt/mingw/libuv")
 
 # modify default behavior of FIND_XXX() commands
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)

--- a/src/server.c
+++ b/src/server.c
@@ -1395,13 +1395,15 @@ void vws_tcp_svr_stop(vws_tcp_svr* server)
 
     while (server->state != VS_HALTED)
     {
-        sleep(1);
+        // uv_sleep() is portable (POSIX sleep() is unavailable on Windows);
+        // 1000 ms matches the original sleep(1). This is a libuv TU already.
+        uv_sleep(1000);
     }
 }
 
-int vws_tcp_svr_inetd_run(vws_tcp_svr* server, int sockfd)
+int vws_tcp_svr_inetd_run(vws_tcp_svr* server, vws_sockfd_t sockfd)
 {
-    if (sockfd < 0)
+    if (sockfd == VWS_INVALID_SOCKET)
     {
         vws.error(VE_RT, "Invalid server or socket descriptor provided");
         return 1;
@@ -1536,7 +1538,7 @@ void vws_tcp_svr_inetd_stop(vws_tcp_svr* server)
 
 bool svr_resolve(cstr host, int port, struct sockaddr_storage** s)
 {
-    int sockfd = -1;
+    vws_sockfd_t sockfd = VWS_INVALID_SOCKET;
 
     // Resolve the host
     struct addrinfo hints, *res, *res0;
@@ -1568,7 +1570,7 @@ bool svr_resolve(cstr host, int port, struct sockaddr_storage** s)
     {
         sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
 
-        if (sockfd == -1)
+        if (sockfd == VWS_INVALID_SOCKET)
         {
             vws.error(VE_SYS, "Failed to create socket");
             continue;
@@ -1591,8 +1593,12 @@ bool svr_resolve(cstr host, int port, struct sockaddr_storage** s)
 
         if (connect(sockfd, res->ai_addr, res->ai_addrlen) == -1)
         {
+#if defined(__windows__)
+            closesocket(sockfd);
+#else
             close(sockfd);
-            sockfd = -1;
+#endif
+            sockfd = VWS_INVALID_SOCKET;
 
             vws.error(VE_SYS, "Failed to connect");
             continue;
@@ -1604,13 +1610,17 @@ bool svr_resolve(cstr host, int port, struct sockaddr_storage** s)
     // Free the addrinfo structure for this host
     freeaddrinfo(res0);
 
-    if (sockfd == -1)
+    if (sockfd == VWS_INVALID_SOCKET)
     {
         vws.error(VE_SYS, "Unable to resolve host %s:%lu", host, port);
         return false;
     }
 
+#if defined(__windows__)
+    closesocket(sockfd);
+#else
     close(sockfd);
+#endif
 
     return true;
 }
@@ -1620,8 +1630,8 @@ bool vws_tcp_svr_peer_connect(vws_tcp_svr* s, vws_peer* peer, void* x)
     // Attempt reconnection
     peer->sockfd = peer->connect(peer, x);
 
-    // Successful it sockfd not -1
-    return (peer->sockfd != -1);
+    // Successful if sockfd is valid
+    return (peer->sockfd != VWS_INVALID_SOCKET);
 }
 
 void vws_tcp_svr_peer_disconnect(vws_tcp_svr* s, vws_peer* peer)

--- a/src/server.h
+++ b/src/server.h
@@ -1,6 +1,19 @@
 #ifndef VRTQL_SVR_DECLARE
 #define VRTQL_SVR_DECLARE
 
+#if defined(__windows__)
+// uv.h pulls <winsock2.h> and <windows.h> on Windows. Without
+// WIN32_LEAN_AND_MEAN, <windows.h> includes the RPC header chain, whose
+// <rpc.h> resolves to vws's own src/rpc.h (src/ is on the include path),
+// dragging the vws header chain into the middle of <windows.h> before SOCKET
+// is defined. WIN32_LEAN_AND_MEAN excludes the RPC chain entirely. Mirrors the
+// guard in socket.c. Must precede <uv.h>.
+#define WIN32_LEAN_AND_MEAN
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0601  // Windows 7 or later
+#endif
+#endif
+
 #include <uv.h>
 
 /*
@@ -257,9 +270,9 @@ struct vws_peer;
  * @param peer The peer struct (containing host and IP)
  * @param x The user-defined context
  * @return Returns the established socket descriptor upon successful connection,
- *   -1 on failure.
+ *   VWS_INVALID_SOCKET on failure.
 */
-typedef int (*vws_peer_connect)(struct vws_peer* p, void* x);
+typedef vws_sockfd_t (*vws_peer_connect)(struct vws_peer* p, void* x);
 
 /** This is used to associate connection info with uv_stream_t handles */
 typedef struct vws_peer
@@ -268,7 +281,7 @@ typedef struct vws_peer
     int port;
     struct vws_cinfo info;
     vws_peer_state_t state;
-    int sockfd;
+    vws_sockfd_t sockfd;
     vws_peer_connect connect;
     void* data;
 } vws_peer;
@@ -674,7 +687,7 @@ bool vws_tcp_svr_is_halted(vws_tcp_svr* server);
  * @param sockfd The incoming socket
  * @return 0 if successful, an error code otherwise.
  */
-int vws_tcp_svr_inetd_run(vws_tcp_svr* server, int sockfd);
+int vws_tcp_svr_inetd_run(vws_tcp_svr* server, vws_sockfd_t sockfd);
 
 /**
  * @brief Stops a VRTQL server running in inetd_mode.


### PR DESCRIPTION
**Unit B** of the Windows port (`9309729a02`) — the final unit, closing out the full Win64 cross-compile track (client core #18 → SOCKET-handle #20 → server now).

## Change (3 files: config/windows-toolchain.cmake, src/server.c, src/server.h)
- `WIN32_LEAN_AND_MEAN` before `<uv.h>`/windows headers (excludes the RPC chain that collides).
- POSIX→portable: `sleep()` → `uv_sleep()`, `close()` → `closesocket()` on Windows.
- Server socket sites → `vws_sockfd_t` (`vws_peer.sockfd`, `inetd_run(vws_sockfd_t sockfd)`), continuing the #20 native-handle work.
- Toolchain: `CMAKE_FIND_ROOT_PATH` + `/opt/mingw/libuv` (libuv cross-built + staged locally, no root).

## ⚠️ Public-API note (for your merge-review)
The `vws_peer_connect` callback typedef **return type changed `int` → `vws_sockfd_t`** — a **public-typedef change**. wc3 confirmed POSIX-safe (only test-layer implementors in-tree, no Windows consumers yet). Flagging so the **agent/vsa vendored embeds reconcile on their next sync**.

## Verified (wc + independent wc3)
- Linux full build 0/0; Win64 MinGW cross 0/0 (`libvws.dll` pe-x86-64); `svr_sp2` 4/4 + `inetd` 1/1 + `rpc_server` 2/2; valgrind `svr_sp2` clean; synthetic-drift caught at `server.c:1542`. No MUST/SHOULD-fix.
- (The inetd valgrind uninit is pre-existing — reproduces on `7a74329`, not introduced here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)