### PR TITLE
Implement vws_svr_run and vrtql_msg_svr_run (were declared-but-undefined)

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2890,6 +2890,14 @@ void vws_svr_free(vws_svr* server)
     vws.free(server);
 }
 
+int vws_svr_run(vws_svr* server, cstr host, int port)
+{
+    // The WebSocket server has no run loop of its own; it is driven through its
+    // base. vws_svr embeds vws_tcp_svr as its first member, so the cast is
+    // layout-sound.
+    return vws_tcp_svr_run((vws_tcp_svr*)server, host, port);
+}
+
 void vws_svr_send_irq(vws_svr* s, vws_cid_t cid, void* data, size_t size)
 {
     vws_tcp_svr* svr = (vws_tcp_svr*)s;
@@ -3001,6 +3009,14 @@ vrtql_msg_svr* vrtql_msg_svr_new(int num_threads, int backlog, int queue_size)
 void vrtql_msg_svr_free(vrtql_msg_svr* server)
 {
     vrtql_msg_svr_dtor(server);
+}
+
+int vrtql_msg_svr_run(vrtql_msg_svr* server, cstr host, int port)
+{
+    // The message server has no run loop of its own; it is driven through its
+    // base. vrtql_msg_svr embeds vws_svr (which embeds vws_tcp_svr) as its first
+    // member, so the cast to the base tcp server is layout-sound.
+    return vws_tcp_svr_run((vws_tcp_svr*)server, host, port);
 }
 
 vrtql_msg_svr*

--- a/src/test/test_msg_server.c
+++ b/src/test/test_msg_server.c
@@ -38,11 +38,12 @@ void process(vws_svr* s, vws_cid_t cid, vrtql_msg* m, void* ctx)
 
 void server_thread(void* arg)
 {
-    vws_tcp_svr* server = (vws_tcp_svr*)arg;
-    vws.tracelevel      = VT_THREAD;
-    server->trace       = vws.tracelevel;
+    vrtql_msg_svr* server = (vrtql_msg_svr*)arg;
+    vws.tracelevel        = VT_THREAD;
+    ((vws_tcp_svr*)server)->trace = vws.tracelevel;
 
-    vws_tcp_svr_run(server, server_host, server_port);
+    // Exercise the vrtql_msg_svr run wrapper (forwards to the base run).
+    vrtql_msg_svr_run(server, server_host, server_port);
 
     vws_cleanup();
 }

--- a/src/test/test_ws_server.c
+++ b/src/test/test_ws_server.c
@@ -36,11 +36,12 @@ void process(vws_svr* s, vws_cid_t cid, vws_msg* m, void* ctx)
 
 void server_thread(void* arg)
 {
-    vws_tcp_svr* server = (vws_tcp_svr*)arg;
+    vws_svr* server     = (vws_svr*)arg;
     vws.tracelevel      = VT_THREAD;
-    server->trace       = vws.tracelevel;
+    ((vws_tcp_svr*)server)->trace = vws.tracelevel;
 
-    vws_tcp_svr_run(server, server_host, server_port);
+    // Exercise the vws_svr run wrapper (forwards to the base run).
+    vws_svr_run(server, server_host, server_port);
 
     vws_cleanup();
 }


### PR DESCRIPTION
`vws_svr_run` (server.h) and `vrtql_msg_svr_run` were declared public but had **no definition** — any consumer calling them by their natural per-tier name got a link error (ticket `d153bf27f7`). The working idiom was the `(vws_tcp_svr*)` base-cast.

Implements both as **thin forwarders** to `vws_tcp_svr_run((vws_tcp_svr*)server, host, port)` (the layout is base-first, so the cast is sound), restoring the declared API to working. Examples/tests can now use the natural name instead of the cast.

## Change (3 files, +25/-7)
- `src/server.c`: the two forwarders.
- `src/test/test_ws_server.c`, `test_msg_server.c`: run via the wrappers (proving they work).

## Verified (wa + independent wa3 on the committed artifact)
`nm` confirms both now defined; built-from-commit 0-warn; `offsetof`/`_Static_assert` layout checks pass; live servers run via the wrappers (ws 1/1, msg 1/1, server no-regress 1/1, 0 orphans); commit-msg==committed-diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)