### PR TITLE
docs: move inline source examples into include/ (consistent htmlize)

### DIFF
--- a/doc/include/ws.api.rpc.client.ex-1.cpp
+++ b/doc/include/ws.api.rpc.client.ex-1.cpp
@@ -1,0 +1,28 @@
+// Create a WebSocket connection and connect
+vws_cnx* cnx = vws_cnx_new();
+vws_connect(cnx, "ws://localhost:8181/websocket");
+
+// Create an RPC instance using the connection
+vrtql_rpc* rpc = vrtql_rpc_new(cnx);
+
+// Create a request message
+vrtql_msg* req = vrtql_msg_new();
+vrtql_msg_set_header(req, "id", "session.login");
+vrtql_msg_set_header(req, "username", "admin");
+vrtql_msg_set_header(req, "password", "secret");
+
+// Make the RPC call (low-level)
+vrtql_msg* reply = vrtql_rpc_exec(rpc, req);
+
+if (reply != NULL)
+{
+    cstr rc = vrtql_msg_get_header(reply, "rc");
+    printf("Return code: %s\n", rc);
+    vrtql_msg_free(reply);
+}
+
+// Cleanup
+vrtql_msg_free(req);
+vrtql_rpc_free(rpc);
+vws_disconnect(cnx);
+vws_cnx_free(cnx);

--- a/doc/include/ws.api.rpc.server.ex-1.cpp
+++ b/doc/include/ws.api.rpc.server.ex-1.cpp
@@ -1,0 +1,44 @@
+// Define RPC handler functions
+vrtql_msg* session_login(vrtql_rpc_env* e, vrtql_msg* req)
+{
+    vrtql_msg* reply = vrtql_rpc_reply(req);
+    vrtql_msg_set_header(reply, "rc", "0");
+    vrtql_msg_set_header(reply, "msg", "Login successful");
+    return reply;
+}
+
+vrtql_msg* session_logout(vrtql_rpc_env* e, vrtql_msg* req)
+{
+    vrtql_msg* reply = vrtql_rpc_reply(req);
+    vrtql_msg_set_header(reply, "rc", "0");
+    return reply;
+}
+
+// Create and populate a module
+vrtql_rpc_module* module = vrtql_rpc_module_new("session");
+vrtql_rpc_module_set(module, "login",  session_login);
+vrtql_rpc_module_set(module, "logout", session_logout);
+
+// Create the system and register the module
+vrtql_rpc_system* system = vrtql_rpc_system_new();
+vrtql_rpc_system_set(system, module);
+
+// Service an incoming request (e.g. from a message server handler)
+vrtql_rpc_env env;
+env.data = NULL;
+
+vrtql_msg* req = vrtql_msg_new();
+vrtql_msg_set_header(req, "id", "session.login");
+
+vrtql_msg* reply = vrtql_rpc_service(system, &env, req);
+
+// reply now contains the handler's response
+// req has been freed by vrtql_rpc_service()
+
+if (reply != NULL)
+{
+    vrtql_msg_free(reply);
+}
+
+// Cleanup
+vrtql_rpc_system_free(system);

--- a/doc/include/ws.ops.config.ex-1.cpp
+++ b/doc/include/ws.ops.config.ex-1.cpp
@@ -1,0 +1,23 @@
+#include <stdlib.h>
+#include <vws/server.h>
+
+int main(int argc, const char* argv[])
+{
+    // Read configuration from environment or defaults
+    cstr host    = getenv("VWS_HOST") ? getenv("VWS_HOST") : "0.0.0.0";
+    int  port    = getenv("VWS_PORT") ? atoi(getenv("VWS_PORT")) : 8181;
+    int  threads = getenv("VWS_THREADS") ? atoi(getenv("VWS_THREADS")) : 10;
+
+    // Create and configure server
+    vrtql_msg_svr* server = vrtql_msg_svr_new(threads, 0, 0);
+    server->process       = my_process_handler;
+
+    // Run (blocks until server is stopped)
+    vrtql_msg_svr_run(server, host, port);
+
+    // Cleanup
+    vrtql_msg_svr_free(server);
+    vws_cleanup();
+
+    return 0;
+}

--- a/doc/xml/ws.api.xml
+++ b/doc/xml/ws.api.xml
@@ -482,36 +482,7 @@ returned string.</para>
 
 <para>The following example illustrates basic client-side RPC usage:
 
-<programlisting>
-// Create a WebSocket connection and connect
-vws_cnx* cnx = vws_cnx_new();
-vws_connect(cnx, "ws://localhost:8181/websocket");
-
-// Create an RPC instance using the connection
-vrtql_rpc* rpc = vrtql_rpc_new(cnx);
-
-// Create a request message
-vrtql_msg* req = vrtql_msg_new();
-vrtql_msg_set_header(req, "id", "session.login");
-vrtql_msg_set_header(req, "username", "admin");
-vrtql_msg_set_header(req, "password", "secret");
-
-// Make the RPC call (low-level)
-vrtql_msg* reply = vrtql_rpc_exec(rpc, req);
-
-if (reply != NULL)
-{
-    cstr rc = vrtql_msg_get_header(reply, "rc");
-    printf("Return code: %s\n", rc);
-    vrtql_msg_free(reply);
-}
-
-// Cleanup
-vrtql_msg_free(req);
-vrtql_rpc_free(rpc);
-vws_disconnect(cnx);
-vws_cnx_free(cnx);
-</programlisting>
+<sourcecode href="ws.api.rpc.client.ex-1.cpp"/>
 
 </para>
 
@@ -568,52 +539,7 @@ the reply format to match the request.</para>
 
 <para>The following example illustrates setting up a server-side RPC system:
 
-<programlisting>
-// Define RPC handler functions
-vrtql_msg* session_login(vrtql_rpc_env* e, vrtql_msg* req)
-{
-    vrtql_msg* reply = vrtql_rpc_reply(req);
-    vrtql_msg_set_header(reply, "rc", "0");
-    vrtql_msg_set_header(reply, "msg", "Login successful");
-    return reply;
-}
-
-vrtql_msg* session_logout(vrtql_rpc_env* e, vrtql_msg* req)
-{
-    vrtql_msg* reply = vrtql_rpc_reply(req);
-    vrtql_msg_set_header(reply, "rc", "0");
-    return reply;
-}
-
-// Create and populate a module
-vrtql_rpc_module* module = vrtql_rpc_module_new("session");
-vrtql_rpc_module_set(module, "login",  session_login);
-vrtql_rpc_module_set(module, "logout", session_logout);
-
-// Create the system and register the module
-vrtql_rpc_system* system = vrtql_rpc_system_new();
-vrtql_rpc_system_set(system, module);
-
-// Service an incoming request (e.g. from a message server handler)
-vrtql_rpc_env env;
-env.data = NULL;
-
-vrtql_msg* req = vrtql_msg_new();
-vrtql_msg_set_header(req, "id", "session.login");
-
-vrtql_msg* reply = vrtql_rpc_service(system, &amp;env, req);
-
-// reply now contains the handler's response
-// req has been freed by vrtql_rpc_service()
-
-if (reply != NULL)
-{
-    vrtql_msg_free(reply);
-}
-
-// Cleanup
-vrtql_rpc_system_free(system);
-</programlisting>
+<sourcecode href="ws.api.rpc.server.ex-1.cpp"/>
 
 </para>
 

--- a/doc/xml/ws.ops.xml
+++ b/doc/xml/ws.ops.xml
@@ -41,31 +41,7 @@ not mandate a particular configuration format, a common approach is to use a
 simple key-value configuration file or environment variables. The following
 illustrates a minimal configuration pattern:
 
-<programlisting>
-#include &lt;stdlib.h&gt;
-#include &lt;vws/server.h&gt;
-
-int main(int argc, const char* argv[])
-{
-    // Read configuration from environment or defaults
-    cstr host    = getenv("VWS_HOST") ? getenv("VWS_HOST") : "0.0.0.0";
-    int  port    = getenv("VWS_PORT") ? atoi(getenv("VWS_PORT")) : 8181;
-    int  threads = getenv("VWS_THREADS") ? atoi(getenv("VWS_THREADS")) : 10;
-
-    // Create and configure server
-    vrtql_msg_svr* server = vrtql_msg_svr_new(threads, 0, 0);
-    server->process       = my_process_handler;
-
-    // Run (blocks until server is stopped)
-    vrtql_msg_svr_run(server, host, port);
-
-    // Cleanup
-    vrtql_msg_svr_free(server);
-    vws_cleanup();
-
-    return 0;
-}
-</programlisting>
+<sourcecode href="ws.ops.config.ex-1.cpp"/>
 
 </para>
 


### PR DESCRIPTION
Makes all doc code examples file-based + htmlized via the `include/` mechanism (not hand-embedded), per the convention.

Extracted the remaining inline C source examples in the existing chapters to `doc/include/` and referenced them with `<sourcecode href>`:
- **ws.ops.xml** — the daemon C program → `ws.ops.config.ex-1.cpp`
- **ws.api.xml** — RPC client + RPC handlers → `ws.api.rpc.client.ex-1.cpp`, `ws.api.rpc.server.ex-1.cpp`

**Left inline** (not source examples): CMake, `haproxy.cfg`, the systemd unit, the init shell script, and the RFC-6455 ASCII frame diagram (a diagram in a comment, not code). Extractions verbatim (un-escaped to raw C); xmllint clean; wp3-reviewed; build-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)